### PR TITLE
Accessing correct container var for config

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -131,8 +131,8 @@ module.exports = function(config, logger) {
                        config.defaultInstanceType ||
                        'm3.medium';
 
-    var imageId = containerDef.specific.ImageId ||
-                  containerDef.specific.imageId ||
+    var imageId = container.specific.ImageId ||
+                  container.specific.imageId ||
                   config.defaultImageId;
 
     var params = {'MaxCount': 1,


### PR DESCRIPTION
While trying to deploy to aws I got an error along the lines of "cannot read property 'ImageId' of undefined." This fixes that.